### PR TITLE
Implied mode addressing and NOP

### DIFF
--- a/src/illNES.CPU/Mos6502.cs
+++ b/src/illNES.CPU/Mos6502.cs
@@ -73,7 +73,10 @@ namespace illNES.CPU
         /// <returns>The number of cycles the Operation "took"</returns>
         private int Exec(Operation op, ushort address)
         {
-            throw new System.NotImplementedException();
+            //TODO implement more ops
+
+            //For now we ignore op, and just NOP!
+            return Operations[0xea].Cycles;
         }
 
         /// <summary>

--- a/src/illNES.CPU/Mos6502.cs
+++ b/src/illNES.CPU/Mos6502.cs
@@ -83,7 +83,11 @@ namespace illNES.CPU
         /// <returns>The address</returns>
         private ushort GetAddress(AddressModes mode)
         {
-            throw new System.NotImplementedException();
+            //TODO implement all addressing modes
+
+            //For now, we ignore `mode` and address using "Implied mode" only
+            //which y'know, does nothing.
+            return 0;
         }
 
         /// <inheritdoc />

--- a/src/illNES.CPU/Types/Operation.cs
+++ b/src/illNES.CPU/Types/Operation.cs
@@ -6,9 +6,9 @@
     internal class Operation
     {
 
-        public Operation(Instructions execCode, AddressModes mode, ushort length, int cycles)
+        public Operation(Instructions instruction, AddressModes mode, ushort length, int cycles)
         {
-            Instruction = execCode;
+            Instruction = instruction;
             Mode = mode;
             Length = length;
             Cycles = cycles;


### PR DESCRIPTION
`Exec()` and `GetAddress()` are now minimally functional, to support `Tick()`